### PR TITLE
adding aws account id and gcp account number and name

### DIFF
--- a/athenz/data_source_all_domain_details.go
+++ b/athenz/data_source_all_domain_details.go
@@ -81,7 +81,6 @@ func dataSourceAllDomainDetailsRead(ctx context.Context, d *schema.ResourceData,
 		d.Set("aws_account_id", domain.Account)
 	}
 	//gcp account number and gcp account name will be together.
-
 	if domain.GcpProject != "" && domain.GcpProjectNumber != "" {
 		d.Set("gcp_project_name", domain.GcpProject)
 		d.Set("gcp_project_number", domain.GcpProjectNumber)

--- a/athenz/data_source_all_domain_details.go
+++ b/athenz/data_source_all_domain_details.go
@@ -80,6 +80,7 @@ func dataSourceAllDomainDetailsRead(ctx context.Context, d *schema.ResourceData,
 	if domain.Account != "" {
 		d.Set("aws_account_id", domain.Account)
 	}
+	//gcp account number and gcp account name will be together.
 
 	if domain.GcpProject != "" && domain.GcpProjectNumber != "" {
 		d.Set("gcp_project_name", domain.GcpProject)

--- a/athenz/data_source_all_domain_details.go
+++ b/athenz/data_source_all_domain_details.go
@@ -18,6 +18,18 @@ func DataSourceAllDomainDetails() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+			"gcp_project_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"gcp_project_number": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"aws_account_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			"role_list": {
 				Type:        schema.TypeSet,
 				Description: "set of all roles",
@@ -64,6 +76,15 @@ func dataSourceAllDomainDetailsRead(ctx context.Context, d *schema.ResourceData,
 		return diag.Errorf("error retrieving Athenz domain: %s", domainName)
 	}
 	d.SetId(string(domain.Name))
+
+	if domain.Account != "" {
+		d.Set("aws_account_id", domain.Account)
+	}
+
+	if domain.GcpProject != "" && domain.GcpProjectNumber != "" {
+		d.Set("gcp_project_name", domain.GcpProject)
+		d.Set("gcp_project_number", domain.GcpProjectNumber)
+	}
 	roleList, err := zmsClient.GetRoleList(domainName, nil, "")
 	if err != nil {
 		return diag.FromErr(err)


### PR DESCRIPTION
Athenz domain contain details about cloud account details. This PR
sets aws account id and gcp account number and gcp account name if it exists as part of the all_domain_details data source.