### PR TITLE
Adding AWS account id and GCP project number and name

### DIFF
--- a/athenz/data_source_all_domain_details.go
+++ b/athenz/data_source_all_domain_details.go
@@ -18,6 +18,18 @@ func DataSourceAllDomainDetails() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+			"gcp_project_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"gcp_project_number": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"aws_account_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			"role_list": {
 				Type:        schema.TypeSet,
 				Description: "set of all roles",
@@ -64,6 +76,14 @@ func dataSourceAllDomainDetailsRead(ctx context.Context, d *schema.ResourceData,
 		return diag.Errorf("error retrieving Athenz domain: %s", domainName)
 	}
 	d.SetId(string(domain.Name))
+
+	if domain.Account != "" {
+		d.Set("aws_account_id", domain.Account)
+	}
+	if domain.GcpProject != "" && domain.GcpProjectNumber != "" {
+		d.Set("gcp_project_name", domain.GcpProject)
+		d.Set("gcp_project_number", domain.GcpProjectNumber)
+	}
 	roleList, err := zmsClient.GetRoleList(domainName, nil, "")
 	if err != nil {
 		return diag.FromErr(err)

--- a/athenz/data_source_all_domain_details.go
+++ b/athenz/data_source_all_domain_details.go
@@ -30,6 +30,10 @@ func DataSourceAllDomainDetails() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"azure_subscription": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			"role_list": {
 				Type:        schema.TypeSet,
 				Description: "set of all roles",
@@ -83,6 +87,9 @@ func dataSourceAllDomainDetailsRead(ctx context.Context, d *schema.ResourceData,
 	if domain.GcpProject != "" && domain.GcpProjectNumber != "" {
 		d.Set("gcp_project_name", domain.GcpProject)
 		d.Set("gcp_project_number", domain.GcpProjectNumber)
+	}
+	if domain.AzureSubscription != "" {
+		d.Set("azure_subscription", domain.AzureSubscription)
 	}
 	roleList, err := zmsClient.GetRoleList(domainName, nil, "")
 	if err != nil {

--- a/docs/data-sources/athenz_all_domain_details.md
+++ b/docs/data-sources/athenz_all_domain_details.md
@@ -28,3 +28,16 @@ data "athenz_all_domain_details" "domain-test" {
 The arguments of this data source act as filters for querying the current Athenz domain.
 
 - `name` - (Required) The name of the specific Athenz domain. Must be fully qualified name.
+
+## Attribute Reference
+
+The following attributes are exported in addition to the `name`
+
+- `aws_account_id` - The accound id from aws if present for the domain
+- `gcp_project_name` - GCP project name if present for the domain
+- `gcp_project_number` - GCP project number if it is present for the domain
+- `azure_subscription` - Azure subscription if present for the domain
+- `role_list` - List of roles for the domain
+- `policy_list` - List of policies in the domain
+- `service_list` - List of services present in the domain
+- `group_list` - List of groups in the domain


### PR DESCRIPTION
Athenz domains contain cloud provider account data. adding gcp and was account data to the data source all_domain_details.