### PR TITLE
Renaming gcp_project_name to gcp_project_id

### DIFF
--- a/athenz/data_source_all_domain_details.go
+++ b/athenz/data_source_all_domain_details.go
@@ -18,7 +18,7 @@ func DataSourceAllDomainDetails() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
-			"gcp_project_name": {
+			"gcp_project_id": {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
@@ -85,7 +85,7 @@ func dataSourceAllDomainDetailsRead(ctx context.Context, d *schema.ResourceData,
 		d.Set("aws_account_id", domain.Account)
 	}
 	if domain.GcpProject != "" && domain.GcpProjectNumber != "" {
-		d.Set("gcp_project_name", domain.GcpProject)
+		d.Set("gcp_project_id", domain.GcpProject)
 		d.Set("gcp_project_number", domain.GcpProjectNumber)
 	}
 	if domain.AzureSubscription != "" {

--- a/docs/data-sources/athenz_all_domain_details.md
+++ b/docs/data-sources/athenz_all_domain_details.md
@@ -34,7 +34,7 @@ The arguments of this data source act as filters for querying the current Athenz
 The following attributes are exported in addition to the `name`
 
 - `aws_account_id` - The accound id from aws if present for the domain
-- `gcp_project_name` - GCP project name if present for the domain
+- `gcp_project_id` - GCP project name if present for the domain
 - `gcp_project_number` - GCP project number if it is present for the domain
 - `azure_subscription` - Azure subscription if present for the domain
 - `role_list` - List of roles for the domain


### PR DESCRIPTION
gcp_project_name is a mutable name, while gcp_project_id is immutable. domain.GcpProject represents gcp_project_id, changing so that it is in sync and does not cause confusion. 