### PR TITLE
Add expand, pending, and only_active to role/group data sources

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+v1.0.52 Release / May 28, 2026
+------------------------------
+- Add expand and pending inputs to athenz_role data source; pending to athenz_group
+- Add only_active filter on athenz_role and athenz_group data sources to drop
+  pending, expired, and system-disabled members
+
 v1.0.51 Release / Apr 11, 2026
 ------------------------------
 - support external members in roles and groups

--- a/athenz/data_source_group.go
+++ b/athenz/data_source_group.go
@@ -127,6 +127,12 @@ func DataSourceGroup() *schema.Resource {
 				Optional: true,
 				Default:  "",
 			},
+			"pending": {
+				Type:        schema.TypeBool,
+				Description: "If set, ZMS will include pending members in the returned group",
+				Optional:    true,
+				Default:     false,
+			},
 		},
 	}
 }
@@ -138,7 +144,8 @@ func dataSourceGroupRead(_ context.Context, d *schema.ResourceData, meta interfa
 	groupName := d.Get("name").(string)
 	fullResourceName := domainName + GROUP_SEPARATOR + groupName
 
-	group, err := zmsClient.GetGroup(domainName, groupName)
+	pending := d.Get("pending").(bool)
+	group, err := zmsClient.GetGroup(domainName, groupName, &pending)
 	switch v := err.(type) {
 	case rdl.ResourceError:
 		if v.Code == 404 {

--- a/athenz/data_source_group.go
+++ b/athenz/data_source_group.go
@@ -133,6 +133,12 @@ func DataSourceGroup() *schema.Resource {
 				Optional:    true,
 				Default:     false,
 			},
+			"only_active": {
+				Type:        schema.TypeBool,
+				Description: "If set, filter the returned members to drop pending, expired, and system-disabled entries",
+				Optional:    true,
+				Default:     false,
+			},
 		},
 	}
 }
@@ -158,8 +164,12 @@ func dataSourceGroupRead(_ context.Context, d *schema.ResourceData, meta interfa
 	}
 	d.SetId(fullResourceName)
 
-	if len(group.GroupMembers) > 0 {
-		if err = d.Set("member", flattenGroupMembers(group.GroupMembers)); err != nil {
+	members := group.GroupMembers
+	if d.Get("only_active").(bool) {
+		members = filterActiveGroupMembers(members)
+	}
+	if len(members) > 0 {
+		if err = d.Set("member", flattenGroupMembers(members)); err != nil {
 			return diag.FromErr(err)
 		}
 	}

--- a/athenz/data_source_role.go
+++ b/athenz/data_source_role.go
@@ -24,6 +24,12 @@ func DataSourceRole() *schema.Resource {
 		Optional:    true,
 		Default:     false,
 	}
+	s["only_active"] = &schema.Schema{
+		Type:        schema.TypeBool,
+		Description: "If set, filter the returned members to drop pending, expired, and system-disabled entries",
+		Optional:    true,
+		Default:     false,
+	}
 	return &schema.Resource{
 		ReadContext: dataSourceRoleRead,
 		Schema:      s,
@@ -53,8 +59,12 @@ func dataSourceRoleRead(_ context.Context, d *schema.ResourceData, meta interfac
 	}
 	d.SetId(fullResourceName)
 
-	if len(role.RoleMembers) > 0 {
-		if err = d.Set("member", flattenRoleMembers(role.RoleMembers)); err != nil {
+	members := role.RoleMembers
+	if d.Get("only_active").(bool) {
+		members = filterActiveRoleMembers(members)
+	}
+	if len(members) > 0 {
+		if err = d.Set("member", flattenRoleMembers(members)); err != nil {
 			return diag.FromErr(err)
 		}
 	}

--- a/athenz/data_source_role.go
+++ b/athenz/data_source_role.go
@@ -11,9 +11,22 @@ import (
 )
 
 func DataSourceRole() *schema.Resource {
+	s := dataSourceRoleSchema()
+	s["expand"] = &schema.Schema{
+		Type:        schema.TypeBool,
+		Description: "If set, ZMS will expand delegated and group memberships in the returned role",
+		Optional:    true,
+		Default:     false,
+	}
+	s["pending"] = &schema.Schema{
+		Type:        schema.TypeBool,
+		Description: "If set, ZMS will include pending members in the returned role",
+		Optional:    true,
+		Default:     false,
+	}
 	return &schema.Resource{
 		ReadContext: dataSourceRoleRead,
-		Schema:      dataSourceRoleSchema(),
+		Schema:      s,
 	}
 }
 
@@ -24,7 +37,9 @@ func dataSourceRoleRead(_ context.Context, d *schema.ResourceData, meta interfac
 	rn := d.Get("name").(string)
 	fullResourceName := dn + ROLE_SEPARATOR + rn
 
-	role, err := zmsClient.GetRole(dn, rn)
+	expand := d.Get("expand").(bool)
+	pending := d.Get("pending").(bool)
+	role, err := zmsClient.GetRole(dn, rn, &expand, &pending)
 
 	switch v := err.(type) {
 	case rdl.ResourceError:

--- a/athenz/resource_group.go
+++ b/athenz/resource_group.go
@@ -173,7 +173,7 @@ func resourceGroupCreate(ctx context.Context, d *schema.ResourceData, meta inter
 	dn := d.Get("domain").(string)
 	gn := d.Get("name").(string)
 	fullResourceName := dn + GROUP_SEPARATOR + gn
-	groupCheck, err := zmsClient.GetGroup(dn, gn)
+	groupCheck, err := zmsClient.GetGroup(dn, gn, nil)
 	switch v := err.(type) {
 	case rdl.ResourceError:
 		if v.Code == 404 {
@@ -255,7 +255,7 @@ func resourceGroupRead(_ context.Context, d *schema.ResourceData, meta interface
 		return diag.FromErr(err)
 	}
 
-	group, err := zmsClient.GetGroup(dn, gn)
+	group, err := zmsClient.GetGroup(dn, gn, nil)
 	switch v := err.(type) {
 	case rdl.ResourceError:
 		if v.Code == 404 {
@@ -377,7 +377,7 @@ func resourceGroupUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 		return diag.FromErr(err)
 	}
 	auditRef := d.Get("audit_ref").(string)
-	group, err := zmsClient.GetGroup(dn, gn)
+	group, err := zmsClient.GetGroup(dn, gn, nil)
 
 	if err != nil {
 		return diag.FromErr(err)

--- a/athenz/resource_group_members.go
+++ b/athenz/resource_group_members.go
@@ -74,7 +74,7 @@ func resourceGroupMembersCreate(ctx context.Context, d *schema.ResourceData, met
 	gn := d.Get("name").(string)
 	fullResourceName := dn + GROUP_SEPARATOR + gn
 
-	_, err := zmsClient.GetGroup(dn, gn)
+	_, err := zmsClient.GetGroup(dn, gn, nil)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -112,7 +112,7 @@ func resourceGroupMembersRead(_ context.Context, d *schema.ResourceData, meta in
 		return diag.FromErr(err)
 	}
 
-	group, err := zmsClient.GetGroup(dn, gn)
+	group, err := zmsClient.GetGroup(dn, gn, nil)
 	switch v := err.(type) {
 	case rdl.ResourceError:
 		if v.Code == 404 {
@@ -151,7 +151,7 @@ func resourceGroupMembersUpdate(ctx context.Context, d *schema.ResourceData, met
 	membersToDelete := make([]*zms.GroupMember, 0)
 	membersToAdd := make([]*zms.GroupMember, 0)
 
-	_, err = zmsClient.GetGroup(dn, gn)
+	_, err = zmsClient.GetGroup(dn, gn, nil)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -177,7 +177,7 @@ func resourceGroupMembersDelete(_ context.Context, d *schema.ResourceData, meta 
 		return diag.FromErr(err)
 	}
 	auditRef := d.Get("audit_ref").(string)
-	group, err := zmsClient.GetGroup(dn, gn)
+	group, err := zmsClient.GetGroup(dn, gn, nil)
 	if err != nil {
 		switch v := err.(type) {
 		case rdl.ResourceError:

--- a/athenz/resource_group_members_test.go
+++ b/athenz/resource_group_members_test.go
@@ -101,7 +101,7 @@ func createTestGroupForMembers(dn, gn string) error {
 func cleanAllAccTestGroupMembers(domain string, groups []string) {
 	zmsClient := testAccProvider.Meta().(client.ZmsClient)
 	for _, groupName := range groups {
-		_, err := zmsClient.GetGroup(domain, groupName)
+		_, err := zmsClient.GetGroup(domain, groupName, nil)
 		if err == nil {
 			if err = zmsClient.DeleteGroup(domain, groupName, AUDIT_REF); err != nil {
 				log.Printf("error deleting Group %s: %s", groupName, err)
@@ -125,7 +125,7 @@ func testAccCheckGroupMembersExists(resourceName string) resource.TestCheckFunc 
 		dn, gn := fullResourceName[0], fullResourceName[1]
 
 		zmsClient := testAccProvider.Meta().(client.ZmsClient)
-		_, err := zmsClient.GetGroup(dn, gn)
+		_, err := zmsClient.GetGroup(dn, gn, nil)
 		if err != nil {
 			return err
 		}
@@ -144,7 +144,7 @@ func testAccCheckGroupMembersDestroy(s *terraform.State) error {
 		fullResourceName := strings.Split(rs.Primary.ID, GROUP_SEPARATOR)
 		dn, gn := fullResourceName[0], fullResourceName[1]
 
-		group, err := zmsClient.GetGroup(dn, gn)
+		group, err := zmsClient.GetGroup(dn, gn, nil)
 		if err == nil {
 			if group.GroupMembers != nil && len(group.GroupMembers) > 0 {
 				return fmt.Errorf("athenz Group Members still exists")

--- a/athenz/resource_group_meta.go
+++ b/athenz/resource_group_meta.go
@@ -126,7 +126,7 @@ func ResourceGroupMeta() *schema.Resource {
 
 func createNewGroupIfNecessary(zmsClient client.ZmsClient, dn, gn string) error {
 	// if group exists already, we don't need to create it
-	_, err := zmsClient.GetGroup(dn, gn)
+	_, err := zmsClient.GetGroup(dn, gn, nil)
 	if err == nil {
 		return nil
 	}
@@ -171,7 +171,7 @@ func resourceGroupMetaCreate(ctx context.Context, d *schema.ResourceData, meta i
 
 func updateGroupMeta(zmsClient client.ZmsClient, dn, gn string, d *schema.ResourceData) diag.Diagnostics {
 
-	group, err := zmsClient.GetGroup(dn, gn)
+	group, err := zmsClient.GetGroup(dn, gn, nil)
 	if err != nil {
 		return diag.Errorf("unable to fetch group %s in domain %s: %v", gn, dn, err)
 	}
@@ -247,7 +247,7 @@ func resourceGroupMetaRead(_ context.Context, d *schema.ResourceData, meta inter
 	if err = d.Set("name", gn); err != nil {
 		return diag.FromErr(err)
 	}
-	group, err := zmsClient.GetGroup(dn, gn)
+	group, err := zmsClient.GetGroup(dn, gn, nil)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/athenz/resource_group_meta_test.go
+++ b/athenz/resource_group_meta_test.go
@@ -59,7 +59,7 @@ func TestAccGroupMetaBasic(t *testing.T) {
 
 func cleanAccTestGroupMeta(domainName, groupName string) {
 	zmsClient := testAccProvider.Meta().(client.ZmsClient)
-	_, err := zmsClient.GetGroup(domainName, groupName)
+	_, err := zmsClient.GetGroup(domainName, groupName, nil)
 	if err == nil {
 		var zero int32
 		zero = 0
@@ -102,7 +102,7 @@ func testAccCheckGroupMetaExists(resource string) resource.TestCheckFunc {
 			return err
 		}
 		zmsClient := testAccProvider.Meta().(client.ZmsClient)
-		group, err := zmsClient.GetGroup(dn, gn)
+		group, err := zmsClient.GetGroup(dn, gn, nil)
 		if err != nil {
 			return err
 		}
@@ -127,7 +127,7 @@ func testAccCheckGroupMetaDestroy(s *terraform.State) error {
 		if err != nil {
 			return err
 		}
-		group, err := zmsClient.GetGroup(dn, gn)
+		group, err := zmsClient.GetGroup(dn, gn, nil)
 		if err != nil {
 			return err
 		}
@@ -222,7 +222,7 @@ func testAccCheckGroupMetaResourceStateDeleteDestroy(s *terraform.State) error {
 			return err
 		}
 		// make sure our group is deleted and 404 is returned
-		_, err = zmsClient.GetGroup(dn, gn)
+		_, err = zmsClient.GetGroup(dn, gn, nil)
 		if err == nil {
 			_ = zmsClient.DeleteGroup(dn, gn, AUDIT_REF)
 			return fmt.Errorf("athenz group still exists")

--- a/athenz/resource_group_test.go
+++ b/athenz/resource_group_test.go
@@ -478,7 +478,7 @@ func TestAccGroupInvalidResource(t *testing.T) {
 func cleanAllAccTestGroups(domain string, groups []string) {
 	zmsClient := testAccProvider.Meta().(client.ZmsClient)
 	for _, groupName := range groups {
-		_, err := zmsClient.GetGroup(domain, groupName)
+		_, err := zmsClient.GetGroup(domain, groupName, nil)
 		if err == nil {
 			if err = zmsClient.DeleteGroup(domain, groupName, AUDIT_REF); err != nil {
 				log.Printf("error deleting Group %s: %s", groupName, err)
@@ -502,7 +502,7 @@ func testAccCheckGroupExists(resourceName string, g *zms.Group) resource.TestChe
 		dn, gn := fullResourceName[0], fullResourceName[1]
 
 		zmsClient := testAccProvider.Meta().(client.ZmsClient)
-		group, err := zmsClient.GetGroup(dn, gn)
+		group, err := zmsClient.GetGroup(dn, gn, nil)
 
 		if err != nil {
 			return err
@@ -524,7 +524,7 @@ func testAccCheckGroupDestroy(s *terraform.State) error {
 		fullResourceName := strings.Split(rs.Primary.ID, GROUP_SEPARATOR)
 		dn, gn := fullResourceName[0], fullResourceName[1]
 
-		_, err := zmsClient.GetGroup(dn, gn)
+		_, err := zmsClient.GetGroup(dn, gn, nil)
 
 		if err == nil {
 			return fmt.Errorf("athenz Group still exists")

--- a/athenz/resource_policy_test.go
+++ b/athenz/resource_policy_test.go
@@ -282,7 +282,7 @@ func cleanAllAccTestPolicies(domain string, policies, roles []string) {
 		}
 	}
 	for _, roleName := range roles {
-		_, err := zmsClient.GetRole(domain, roleName)
+		_, err := zmsClient.GetRole(domain, roleName, nil, nil)
 		if err == nil {
 			if err = zmsClient.DeleteRole(domain, roleName, AUDIT_REF); err != nil {
 				log.Printf("error deleting Role %s: %s", roleName, err)

--- a/athenz/resource_policy_version_test.go
+++ b/athenz/resource_policy_version_test.go
@@ -226,7 +226,7 @@ func cleanAllAccTestPoliciesVersion(domain string, policies []string, roles []st
 		}
 	}
 	for _, roleName := range roles {
-		_, err := zmsClient.GetRole(domain, roleName)
+		_, err := zmsClient.GetRole(domain, roleName, nil, nil)
 		if err == nil {
 			if err = zmsClient.DeleteRole(domain, roleName, AUDIT_REF); err != nil {
 				log.Printf("error deleting Role %s: %s", roleName, err)

--- a/athenz/resource_role.go
+++ b/athenz/resource_role.go
@@ -236,7 +236,7 @@ func resourceRoleCreate(ctx context.Context, d *schema.ResourceData, meta interf
 	rn := d.Get("name").(string)
 	fullResourceName := dn + ROLE_SEPARATOR + rn
 
-	roleCheck, err := zmsClient.GetRole(dn, rn)
+	roleCheck, err := zmsClient.GetRole(dn, rn, nil, nil)
 	switch v := err.(type) {
 	case rdl.ResourceError:
 		if v.Code == 404 {
@@ -340,7 +340,7 @@ func resourceRoleRead(_ context.Context, d *schema.ResourceData, meta interface{
 	if err = d.Set("name", rn); err != nil {
 		return diag.FromErr(err)
 	}
-	role, err := zmsClient.GetRole(dn, rn)
+	role, err := zmsClient.GetRole(dn, rn, nil, nil)
 	switch v := err.(type) {
 	case rdl.ResourceError:
 		if v.Code == 404 {
@@ -521,7 +521,7 @@ func resourceRoleUpdate(ctx context.Context, d *schema.ResourceData, meta interf
 	}
 	auditRef := d.Get("audit_ref").(string)
 
-	role, err := zmsClient.GetRole(dn, rn)
+	role, err := zmsClient.GetRole(dn, rn, nil, nil)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/athenz/resource_role_members.go
+++ b/athenz/resource_role_members.go
@@ -78,7 +78,7 @@ func resourceRoleMembersCreate(ctx context.Context, d *schema.ResourceData, meta
 	rn := d.Get("name").(string)
 	fullResourceName := dn + ROLE_SEPARATOR + rn
 
-	_, err := zmsClient.GetRole(dn, rn)
+	_, err := zmsClient.GetRole(dn, rn, nil, nil)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -116,7 +116,7 @@ func resourceRoleMembersRead(_ context.Context, d *schema.ResourceData, meta int
 	if err = d.Set("name", rn); err != nil {
 		return diag.FromErr(err)
 	}
-	role, err := zmsClient.GetRole(dn, rn)
+	role, err := zmsClient.GetRole(dn, rn, nil, nil)
 	switch v := err.(type) {
 	case rdl.ResourceError:
 		if v.Code == 404 {
@@ -155,7 +155,7 @@ func resourceRoleMembersUpdate(ctx context.Context, d *schema.ResourceData, meta
 	membersToDelete := make([]*zms.RoleMember, 0)
 	membersToAdd := make([]*zms.RoleMember, 0)
 
-	_, err = zmsClient.GetRole(dn, rn)
+	_, err = zmsClient.GetRole(dn, rn, nil, nil)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -192,7 +192,7 @@ func resourceRoleMembersDelete(_ context.Context, d *schema.ResourceData, meta i
 		return diag.FromErr(err)
 	}
 	auditRef := d.Get("audit_ref").(string)
-	role, err := zmsClient.GetRole(dn, rn)
+	role, err := zmsClient.GetRole(dn, rn, nil, nil)
 	if err != nil {
 		switch v := err.(type) {
 		case rdl.ResourceError:

--- a/athenz/resource_role_members_test.go
+++ b/athenz/resource_role_members_test.go
@@ -104,7 +104,7 @@ func TestAccRoleMembersBasic(t *testing.T) {
 func cleanAllAccTestRoleMembers(domain string, roles []string) {
 	zmsClient := testAccProvider.Meta().(client.ZmsClient)
 	for _, roleName := range roles {
-		_, err := zmsClient.GetRole(domain, roleName)
+		_, err := zmsClient.GetRole(domain, roleName, nil, nil)
 		if err == nil {
 			if err = zmsClient.DeleteRole(domain, roleName, AUDIT_REF); err != nil {
 				log.Printf("error deleting Role %s: %s", roleName, err)
@@ -135,7 +135,7 @@ func testAccCheckRoleMembersExists(n string) resource.TestCheckFunc {
 		dn, rn := fullResourceName[0], fullResourceName[1]
 
 		zmsClient := testAccProvider.Meta().(client.ZmsClient)
-		_, err := zmsClient.GetRole(dn, rn)
+		_, err := zmsClient.GetRole(dn, rn, nil, nil)
 		if err != nil {
 			role := zms.Role{
 				Name: zms.ResourceName(rn),
@@ -213,7 +213,7 @@ func testAccCheckRoleMembersDestroy(s *terraform.State) error {
 		fullResourceName := strings.Split(rs.Primary.ID, ROLE_SEPARATOR)
 		dn, rn := fullResourceName[0], fullResourceName[1]
 
-		role, err := zmsClient.GetRole(dn, rn)
+		role, err := zmsClient.GetRole(dn, rn, nil, nil)
 		if err == nil {
 			if role.RoleMembers != nil && len(role.RoleMembers) > 0 {
 				return fmt.Errorf("athenz Role Members still exists")

--- a/athenz/resource_role_meta.go
+++ b/athenz/resource_role_meta.go
@@ -164,7 +164,7 @@ func ResourceRoleMeta() *schema.Resource {
 
 func createNewRoleIfNecessary(zmsClient client.ZmsClient, dn, rn string) error {
 	// if role exists already, we don't need to create it
-	_, err := zmsClient.GetRole(dn, rn)
+	_, err := zmsClient.GetRole(dn, rn, nil, nil)
 	if err == nil {
 		return nil
 	}
@@ -209,7 +209,7 @@ func resourceRoleMetaCreate(ctx context.Context, d *schema.ResourceData, meta in
 
 func updateRoleMeta(zmsClient client.ZmsClient, dn, rn string, d *schema.ResourceData) diag.Diagnostics {
 
-	role, err := zmsClient.GetRole(dn, rn)
+	role, err := zmsClient.GetRole(dn, rn, nil, nil)
 	if err != nil {
 		return diag.Errorf("unable to fetch role %s in domain %s: %v", rn, dn, err)
 	}
@@ -319,7 +319,7 @@ func resourceRoleMetaRead(_ context.Context, d *schema.ResourceData, meta interf
 	if err = d.Set("name", rn); err != nil {
 		return diag.FromErr(err)
 	}
-	role, err := zmsClient.GetRole(dn, rn)
+	role, err := zmsClient.GetRole(dn, rn, nil, nil)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/athenz/resource_role_meta_test.go
+++ b/athenz/resource_role_meta_test.go
@@ -66,7 +66,7 @@ func TestAccRoleMetaBasic(t *testing.T) {
 
 func cleanAccTestRoleMeta(domainName, roleName string) {
 	zmsClient := testAccProvider.Meta().(client.ZmsClient)
-	_, err := zmsClient.GetRole(domainName, roleName)
+	_, err := zmsClient.GetRole(domainName, roleName, nil, nil)
 	if err == nil {
 		var zero int32
 		zero = 0
@@ -117,7 +117,7 @@ func testAccCheckRoleMetaExists(resource string) resource.TestCheckFunc {
 			return err
 		}
 		zmsClient := testAccProvider.Meta().(client.ZmsClient)
-		role, err := zmsClient.GetRole(dn, rn)
+		role, err := zmsClient.GetRole(dn, rn, nil, nil)
 		if err != nil {
 			return err
 		}
@@ -139,7 +139,7 @@ func testAccCheckRoleMetaDestroy(s *terraform.State) error {
 		if err != nil {
 			return err
 		}
-		role, err := zmsClient.GetRole(dn, rn)
+		role, err := zmsClient.GetRole(dn, rn, nil, nil)
 		if err != nil {
 			return err
 		}
@@ -245,7 +245,7 @@ func testAccCheckRoleMetaResourceStateDeleteDestroy(s *terraform.State) error {
 			return err
 		}
 		// make sure our role is deleted and 404 is returned
-		_, err = zmsClient.GetRole(dn, rn)
+		_, err = zmsClient.GetRole(dn, rn, nil, nil)
 		if err == nil {
 			_ = zmsClient.DeleteRole(dn, rn, AUDIT_REF)
 			return fmt.Errorf("athenz role still exists")

--- a/athenz/resource_role_test.go
+++ b/athenz/resource_role_test.go
@@ -955,7 +955,7 @@ func TestAccGroupRoleInvalidResource(t *testing.T) {
 func cleanAllAccTestRoles(domain string, roles []string) {
 	zmsClient := testAccProvider.Meta().(client.ZmsClient)
 	for _, roleName := range roles {
-		_, err := zmsClient.GetRole(domain, roleName)
+		_, err := zmsClient.GetRole(domain, roleName, nil, nil)
 		if err == nil {
 			if err = zmsClient.DeleteRole(domain, roleName, AUDIT_REF); err != nil {
 				log.Printf("error deleting Role %s: %s", roleName, err)
@@ -978,7 +978,7 @@ func testAccCheckGroupRoleExists(n string, r *zms.Role) resource.TestCheckFunc {
 		dn, rn := fullResourceName[0], fullResourceName[1]
 
 		zmsClient := testAccProvider.Meta().(client.ZmsClient)
-		role, err := zmsClient.GetRole(dn, rn)
+		role, err := zmsClient.GetRole(dn, rn, nil, nil)
 
 		if err != nil {
 			return err
@@ -1171,7 +1171,7 @@ func testAccCheckGroupRoleDestroy(s *terraform.State) error {
 		fullResourceName := strings.Split(rs.Primary.ID, ROLE_SEPARATOR)
 		dn, rn := fullResourceName[0], fullResourceName[1]
 
-		_, err := zmsClient.GetRole(dn, rn)
+		_, err := zmsClient.GetRole(dn, rn, nil, nil)
 		if err == nil {
 			return fmt.Errorf("athenz Group Role still exists")
 		}

--- a/athenz/resource_self_serve_group_members.go
+++ b/athenz/resource_self_serve_group_members.go
@@ -72,7 +72,7 @@ func resourceSelfServeGroupMembersCreate(ctx context.Context, d *schema.Resource
 	gn := d.Get("name").(string)
 	fullResourceName := dn + GROUP_SEPARATOR + gn
 
-	_, err := zmsClient.GetGroup(dn, gn)
+	_, err := zmsClient.GetGroup(dn, gn, nil)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -109,7 +109,7 @@ func resourceSelfServeGroupMembersRead(_ context.Context, d *schema.ResourceData
 	if err = d.Set("name", gn); err != nil {
 		return diag.FromErr(err)
 	}
-	_, err = zmsClient.GetGroup(dn, gn)
+	_, err = zmsClient.GetGroup(dn, gn, nil)
 	switch v := err.(type) {
 	case rdl.ResourceError:
 		if v.Code == 404 {
@@ -151,7 +151,7 @@ func resourceSelfServeGroupMembersUpdate(ctx context.Context, d *schema.Resource
 	membersToDelete := make([]*zms.GroupMember, 0)
 	membersToAdd := make([]*zms.GroupMember, 0)
 
-	_, err = zmsClient.GetGroup(dn, gn)
+	_, err = zmsClient.GetGroup(dn, gn, nil)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/athenz/resource_self_serve_group_members_test.go
+++ b/athenz/resource_self_serve_group_members_test.go
@@ -155,7 +155,7 @@ func TestAccSelfServeGroupMembersExternalMembers(t *testing.T) {
 func cleanAllAccTestSelfServeGroupMembers(domain string, groups []string) {
 	zmsClient := testAccProvider.Meta().(client.ZmsClient)
 	for _, groupName := range groups {
-		_, err := zmsClient.GetGroup(domain, groupName)
+		_, err := zmsClient.GetGroup(domain, groupName, nil)
 		if err == nil {
 			if err = zmsClient.DeleteGroup(domain, groupName, AUDIT_REF); err != nil {
 				log.Printf("error deleting Group %s: %s", groupName, err)
@@ -186,7 +186,7 @@ func testAccCheckSelfServeGroupMembersExists(n string) resource.TestCheckFunc {
 		dn, gn := fullResourceName[0], fullResourceName[1]
 
 		zmsClient := testAccProvider.Meta().(client.ZmsClient)
-		_, err := zmsClient.GetGroup(dn, gn)
+		_, err := zmsClient.GetGroup(dn, gn, nil)
 		if err != nil {
 			group := zms.Group{
 				Name: zms.ResourceName(gn),
@@ -202,7 +202,7 @@ func testAccCheckSelfServeGroupMembersExists(n string) resource.TestCheckFunc {
 func testAccCheckExternalGroupMemberStillExists(domain, group, member string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		zmsClient := testAccProvider.Meta().(client.ZmsClient)
-		groupData, err := zmsClient.GetGroup(domain, group)
+		groupData, err := zmsClient.GetGroup(domain, group, nil)
 		if err != nil {
 			return err
 		}
@@ -281,7 +281,7 @@ func testAccCheckSelfServeGroupMembersDestroy(s *terraform.State) error {
 		fullResourceName := strings.Split(rs.Primary.ID, GROUP_SEPARATOR)
 		dn, gn := fullResourceName[0], fullResourceName[1]
 
-		group, err := zmsClient.GetGroup(dn, gn)
+		group, err := zmsClient.GetGroup(dn, gn, nil)
 		if err == nil {
 			if len(group.GroupMembers) > 0 {
 				return fmt.Errorf("athenz Self Serve Group Members still exists")
@@ -304,7 +304,7 @@ func testAccCheckSelfServeGroupExternalMembersDestroy(s *terraform.State) error 
 		fullResourceName := strings.Split(rs.Primary.ID, GROUP_SEPARATOR)
 		dn, gn := fullResourceName[0], fullResourceName[1]
 
-		group, err := zmsClient.GetGroup(dn, gn)
+		group, err := zmsClient.GetGroup(dn, gn, nil)
 		if err == nil {
 			if len(group.GroupMembers) == 0 {
 				return fmt.Errorf("athenz ext group member should be present")

--- a/athenz/resource_self_serve_role_members.go
+++ b/athenz/resource_self_serve_role_members.go
@@ -78,7 +78,7 @@ func resourceSelfServeRoleMembersCreate(ctx context.Context, d *schema.ResourceD
 	rn := d.Get("name").(string)
 	fullResourceName := dn + ROLE_SEPARATOR + rn
 
-	_, err := zmsClient.GetRole(dn, rn)
+	_, err := zmsClient.GetRole(dn, rn, nil, nil)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -116,7 +116,7 @@ func resourceSelfServeRoleMembersRead(_ context.Context, d *schema.ResourceData,
 	if err = d.Set("name", rn); err != nil {
 		return diag.FromErr(err)
 	}
-	_, err = zmsClient.GetRole(dn, rn)
+	_, err = zmsClient.GetRole(dn, rn, nil, nil)
 	switch v := err.(type) {
 	case rdl.ResourceError:
 		if v.Code == 404 {
@@ -158,7 +158,7 @@ func resourceSelfServeRoleMembersUpdate(ctx context.Context, d *schema.ResourceD
 	membersToDelete := make([]*zms.RoleMember, 0)
 	membersToAdd := make([]*zms.RoleMember, 0)
 
-	_, err = zmsClient.GetRole(dn, rn)
+	_, err = zmsClient.GetRole(dn, rn, nil, nil)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/athenz/resource_self_serve_role_members_test.go
+++ b/athenz/resource_self_serve_role_members_test.go
@@ -165,7 +165,7 @@ func TestAccSelfServeRoleMembersExternalMembers(t *testing.T) {
 func cleanAllAccTestSelfServeRoleMembers(domain string, roles []string) {
 	zmsClient := testAccProvider.Meta().(client.ZmsClient)
 	for _, roleName := range roles {
-		_, err := zmsClient.GetRole(domain, roleName)
+		_, err := zmsClient.GetRole(domain, roleName, nil, nil)
 		if err == nil {
 			if err = zmsClient.DeleteRole(domain, roleName, AUDIT_REF); err != nil {
 				log.Printf("error deleting Role %s: %s", roleName, err)
@@ -196,7 +196,7 @@ func testAccCheckSelfServeRoleMembersExists(n string) resource.TestCheckFunc {
 		dn, rn := fullResourceName[0], fullResourceName[1]
 
 		zmsClient := testAccProvider.Meta().(client.ZmsClient)
-		_, err := zmsClient.GetRole(dn, rn)
+		_, err := zmsClient.GetRole(dn, rn, nil, nil)
 		if err != nil {
 			role := zms.Role{
 				Name: zms.ResourceName(rn),
@@ -212,7 +212,7 @@ func testAccCheckSelfServeRoleMembersExists(n string) resource.TestCheckFunc {
 func testAccCheckExternalMemberStillExists(domain, role, member string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		zmsClient := testAccProvider.Meta().(client.ZmsClient)
-		roleData, err := zmsClient.GetRole(domain, role)
+		roleData, err := zmsClient.GetRole(domain, role, nil, nil)
 		if err != nil {
 			return err
 		}
@@ -291,7 +291,7 @@ func testAccCheckSelfServeRoleMembersDestroy(s *terraform.State) error {
 		fullResourceName := strings.Split(rs.Primary.ID, ROLE_SEPARATOR)
 		dn, rn := fullResourceName[0], fullResourceName[1]
 
-		role, err := zmsClient.GetRole(dn, rn)
+		role, err := zmsClient.GetRole(dn, rn, nil, nil)
 		if err == nil {
 			if len(role.RoleMembers) > 0 {
 				return fmt.Errorf("athenz Self Serve Role Members still exists")
@@ -314,7 +314,7 @@ func testAccCheckSelfServeRoleExternalMembersDestroy(s *terraform.State) error {
 		fullResourceName := strings.Split(rs.Primary.ID, ROLE_SEPARATOR)
 		dn, rn := fullResourceName[0], fullResourceName[1]
 
-		role, err := zmsClient.GetRole(dn, rn)
+		role, err := zmsClient.GetRole(dn, rn, nil, nil)
 		if err == nil {
 			if len(role.RoleMembers) == 0 {
 				return fmt.Errorf("athenz ext role member should be present")

--- a/athenz/resource_sub_domain.go
+++ b/athenz/resource_sub_domain.go
@@ -123,7 +123,7 @@ func resourceSubDomainRead(ctx context.Context, d *schema.ResourceData, meta int
 		return diag.Errorf("error retrieving Athenz Sub Domain - Make sure your cert/key are valid")
 	}
 
-	adminRole, err := zmsClient.GetRole(fullyQualifiedName, "admin")
+	adminRole, err := zmsClient.GetRole(fullyQualifiedName, "admin", nil, nil)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/athenz/resource_top_level_domain.go
+++ b/athenz/resource_top_level_domain.go
@@ -98,7 +98,7 @@ func resourceTopLevelDomainRead(ctx context.Context, d *schema.ResourceData, met
 	if err = d.Set("name", domainName); err != nil {
 		return diag.FromErr(err)
 	}
-	adminRole, err := zmsClient.GetRole(domainName, "admin")
+	adminRole, err := zmsClient.GetRole(domainName, "admin", nil, nil)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/athenz/utils.go
+++ b/athenz/utils.go
@@ -320,6 +320,9 @@ func filterActiveRoleMembers(list []*zms.RoleMember) []*zms.RoleMember {
 	now := time.Now()
 	filtered := make([]*zms.RoleMember, 0, len(list))
 	for _, m := range list {
+		if m == nil {
+			continue
+		}
 		if m.Approved != nil && !*m.Approved {
 			continue
 		}

--- a/athenz/utils.go
+++ b/athenz/utils.go
@@ -314,6 +314,26 @@ func stringToTimestamp(val string) *rdl.Timestamp {
 	return &rdl.Timestamp{Time: expiration}
 }
 
+// filterActiveRoleMembers drops members that are pending (Approved == false),
+// expired (Expiration before now), or system-disabled (SystemDisabled != 0).
+func filterActiveRoleMembers(list []*zms.RoleMember) []*zms.RoleMember {
+	now := time.Now()
+	filtered := make([]*zms.RoleMember, 0, len(list))
+	for _, m := range list {
+		if m.Approved != nil && !*m.Approved {
+			continue
+		}
+		if m.Expiration != nil && m.Expiration.Time.Before(now) {
+			continue
+		}
+		if m.SystemDisabled != nil && *m.SystemDisabled != 0 {
+			continue
+		}
+		filtered = append(filtered, m)
+	}
+	return filtered
+}
+
 func flattenRoleMembers(list []*zms.RoleMember) []interface{} {
 	roleMembers := make([]interface{}, 0, len(list))
 	for _, m := range list {

--- a/athenz/utils_group.go
+++ b/athenz/utils_group.go
@@ -2,10 +2,31 @@ package athenz
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/AthenZ/athenz/clients/go/zms"
 	"github.com/AthenZ/terraform-provider-athenz/client"
 )
+
+// filterActiveGroupMembers drops members that are pending (Approved == false),
+// expired (Expiration before now), or system-disabled (SystemDisabled != 0).
+func filterActiveGroupMembers(list []*zms.GroupMember) []*zms.GroupMember {
+	now := time.Now()
+	filtered := make([]*zms.GroupMember, 0, len(list))
+	for _, m := range list {
+		if m.Approved != nil && !*m.Approved {
+			continue
+		}
+		if m.Expiration != nil && m.Expiration.Time.Before(now) {
+			continue
+		}
+		if m.SystemDisabled != nil && *m.SystemDisabled != 0 {
+			continue
+		}
+		filtered = append(filtered, m)
+	}
+	return filtered
+}
 
 func expandDeprecatedGroupMembers(configured []interface{}) []*zms.GroupMember {
 	groupMembers := make([]*zms.GroupMember, 0, len(configured))

--- a/athenz/utils_group.go
+++ b/athenz/utils_group.go
@@ -14,6 +14,9 @@ func filterActiveGroupMembers(list []*zms.GroupMember) []*zms.GroupMember {
 	now := time.Now()
 	filtered := make([]*zms.GroupMember, 0, len(list))
 	for _, m := range list {
+		if m == nil {
+			continue
+		}
 		if m.Approved != nil && !*m.Approved {
 			continue
 		}

--- a/athenz/utils_group_test.go
+++ b/athenz/utils_group_test.go
@@ -20,7 +20,7 @@ func TestUpdateGroupMembers(t *testing.T) {
 	}
 	mockCtrl := gomock.NewController(t)
 	clientMock := client.NewMockZmsClient(mockCtrl)
-	clientMock.EXPECT().GetRole(gomock.Any(), gomock.Any()).Return(&zms.Role{Name: "test"}, nil).AnyTimes()
+	clientMock.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(&zms.Role{Name: "test"}, nil).AnyTimes()
 	clientMock.EXPECT().PutRole(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 
 	// _ = args{

--- a/client/client.go
+++ b/client/client.go
@@ -26,7 +26,7 @@ var retryDelays = []time.Duration{
 }
 
 type ZmsClient interface {
-	GetRole(domain string, roleName string) (*zms.Role, error)
+	GetRole(domain string, roleName string, expand *bool, pending *bool) (*zms.Role, error)
 	DeleteRole(domain string, roleName string, auditRef string) error
 	PutRole(domain string, roleName string, auditRef string, role *zms.Role) error
 	PutMembership(domain string, roleName string, memberName zms.MemberName, auditRef string, membership *zms.Membership) error
@@ -34,7 +34,7 @@ type ZmsClient interface {
 	PutPolicy(domain string, policyName string, auditRef string, policy *zms.Policy) error
 	GetPolicy(domain string, policy string) (*zms.Policy, error)
 	DeletePolicy(domain string, policyName string, auditRef string) error
-	GetGroup(domain string, groupName string) (*zms.Group, error)
+	GetGroup(domain string, groupName string, pending *bool) (*zms.Group, error)
 	DeleteGroup(domain string, groupName string, auditRef string) error
 	PutGroup(domain string, groupName string, auditRef string, group *zms.Group) error
 	DeleteGroupMembership(domain string, groupName string, member zms.GroupMemberName, auditRef string) error
@@ -582,7 +582,7 @@ func (c Client) DeleteGroup(domain string, groupName string, auditRef string) er
 	return fmt.Errorf("too many requests, retried 3 times but still failed: %w", err)
 }
 
-func (c Client) GetGroup(domain string, groupName string) (*zms.Group, error) {
+func (c Client) GetGroup(domain string, groupName string, pending *bool) (*zms.Group, error) {
 	var (
 		group *zms.Group
 		err   error
@@ -592,7 +592,7 @@ func (c Client) GetGroup(domain string, groupName string) (*zms.Group, error) {
 		if delay > 0 {
 			time.Sleep(delay)
 		}
-		group, err = zmsClient.GetGroup(zms.DomainName(domain), zms.EntityName(groupName), nil, nil)
+		group, err = zmsClient.GetGroup(zms.DomainName(domain), zms.EntityName(groupName), nil, pending)
 		if errObj, ok := err.(rdl.ResourceError); ok && errObj.Code == ErrCodeRateLimit {
 			continue
 		}
@@ -672,7 +672,7 @@ func (c Client) PutAssertionConditions(domainName string, policyName string, ass
 	return nil, fmt.Errorf("too many requests, retried 3 times but still failed: %w", err)
 }
 
-func (c Client) GetRole(domain string, roleName string) (*zms.Role, error) {
+func (c Client) GetRole(domain string, roleName string, expand *bool, pending *bool) (*zms.Role, error) {
 	var (
 		role *zms.Role
 		err  error
@@ -682,7 +682,7 @@ func (c Client) GetRole(domain string, roleName string) (*zms.Role, error) {
 		if delay > 0 {
 			time.Sleep(delay)
 		}
-		role, err = zmsClient.GetRole(zms.DomainName(domain), zms.EntityName(roleName), nil, nil, nil)
+		role, err = zmsClient.GetRole(zms.DomainName(domain), zms.EntityName(roleName), nil, expand, pending)
 		if errObj, ok := err.(rdl.ResourceError); ok && errObj.Code == ErrCodeRateLimit {
 			continue
 		}

--- a/client/mock_client.go
+++ b/client/mock_client.go
@@ -105,18 +105,18 @@ func (mr *MockZmsClientMockRecorder) DeleteRole(domain, roleName, auditRef inter
 }
 
 // GetGroup mocks base method.
-func (m *MockZmsClient) GetGroup(domain, groupName string) (*zms.Group, error) {
+func (m *MockZmsClient) GetGroup(domain, groupName string, pending *bool) (*zms.Group, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetGroup", domain, groupName)
+	ret := m.ctrl.Call(m, "GetGroup", domain, groupName, pending)
 	ret0, _ := ret[0].(*zms.Group)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetGroup indicates an expected call of GetGroup.
-func (mr *MockZmsClientMockRecorder) GetGroup(domain, groupName interface{}) *gomock.Call {
+func (mr *MockZmsClientMockRecorder) GetGroup(domain, groupName, pending interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGroup", reflect.TypeOf((*MockZmsClient)(nil).GetGroup), domain, groupName)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGroup", reflect.TypeOf((*MockZmsClient)(nil).GetGroup), domain, groupName, pending)
 }
 
 // GetPolicy mocks base method.
@@ -135,18 +135,18 @@ func (mr *MockZmsClientMockRecorder) GetPolicy(domain, policy interface{}) *gomo
 }
 
 // GetRole mocks base method.
-func (m *MockZmsClient) GetRole(domain, roleName string) (*zms.Role, error) {
+func (m *MockZmsClient) GetRole(domain, roleName string, expand, pending *bool) (*zms.Role, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetRole", domain, roleName)
+	ret := m.ctrl.Call(m, "GetRole", domain, roleName, expand, pending)
 	ret0, _ := ret[0].(*zms.Role)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetRole indicates an expected call of GetRole.
-func (mr *MockZmsClientMockRecorder) GetRole(domain, roleName interface{}) *gomock.Call {
+func (mr *MockZmsClientMockRecorder) GetRole(domain, roleName, expand, pending interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRole", reflect.TypeOf((*MockZmsClient)(nil).GetRole), domain, roleName)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRole", reflect.TypeOf((*MockZmsClient)(nil).GetRole), domain, roleName, expand, pending)
 }
 
 // PutGroup mocks base method.

--- a/sys-test/expected-terraform-sys-test-results
+++ b/sys-test/expected-terraform-sys-test-results
@@ -9,6 +9,7 @@
   "azureTenant": "",
   "businessService": "",
   "certDnsDomain": "",
+  "costCenter": "",
   "description": "",
   "enabled": true,
   "entities": [],


### PR DESCRIPTION
## Summary

Extend the `athenz_role` and `athenz_group` data sources with three new
inputs that make it easier to query membership directly from Terraform:

- **`expand`** (role only) — forwarded to ZMS so the returned role
  includes expanded delegated-trust and group memberships. The
  underlying `GetGroup` API does not accept `expand`, so this input
  exists only on `athenz_role`.
- **`pending`** — forwarded to ZMS to include pending members
  (`pending_role_member` / `pending_group_member`) in the result.
  Available on both data sources.
- **`only_active`** — client-side filter that drops members where
  `Approved == false`, `Expiration` is in the past, or
  `SystemDisabled` is non-zero. ZMS has no server-side filter for this
  (verified across `GetRole`, `GetGroup`, `GetRoles`, `GetGroups`,
  `DomainRoleMembers`, `getPrincipalRoles`, and the SQL behind
  `listRoleMembers`); per `Role.tdl`, members are expected to be
  filtered client-side based on their attributes.

## Implementation notes

- `ZmsClient.GetRole` interface gains `expand, pending *bool`;
  `ZmsClient.GetGroup` gains `pending *bool`. All existing callers
  (resources and tests) pass `nil` to preserve current behavior.
- The `only_active` filter is applied only in the data sources, not
  the resources — resources still get the raw list so state continues
  to reflect what's actually configured in ZMS.
- Generated mock and `gomock.EXPECT()` calls updated to match the new
  signatures.

## Test plan

- `go build ./...`
- `go test ./athenz/... -count=1 -short`

## CHANGELOG

v1.0.52 entry added covering both the data source pass-through and the
`only_active` filter.
