### PR TITLE
Clone http.DefaultTransport instead of constructing a bare Transport

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -812,17 +812,27 @@ func NewClient(zmsConfig *ZmsConfig) (*Client, error) {
 	if err != nil {
 		return nil, err
 	}
-	transport := http.Transport{
-		TLSClientConfig: tlsConfig,
+	transport := clonedTransport(http.DefaultTransport)
+	if transport == nil {
+		transport = &http.Transport{}
 	}
+	transport.TLSClientConfig = tlsConfig
 	client := &Client{
 		Url:                    zmsConfig.Url,
-		Transport:              &transport,
+		Transport:              transport,
 		ResourceOwner:          zmsConfig.ResourceOwner,
 		RoleMetaResourceState:  zmsConfig.RoleMetaResourceState,
 		GroupMetaResourceState: zmsConfig.GroupMetaResourceState,
 	}
 	return client, err
+}
+
+func clonedTransport(rt http.RoundTripper) *http.Transport {
+	t, ok := rt.(*http.Transport)
+	if !ok || t == nil {
+		return nil
+	}
+	return t.Clone()
 }
 
 func getTLSConfigFromFiles(certFile, keyFile string, caCert string) (*tls.Config, error) {


### PR DESCRIPTION
## Summary

Make the ZMS client respect OS-level HTTP settings by cloning
`http.DefaultTransport` instead of constructing a bare `http.Transport`
with only `TLSClientConfig` set.

The primary motivation is to support environments where the provider
must reach the ZMS server through an HTTP proxy. The old code zeroed
out the `Proxy` field (and all other transport defaults), causing
connections to bypass the proxy and fail in corporate network setups.

## Implementation notes

- `clonedTransport(http.DefaultTransport)` copies all OS
  defaults (proxy from environment, timeouts, keep-alive, connection
  pooling) into a new transport.
- Only `TLSClientConfig` is overridden on the clone, preserving the
  existing certificate-based authentication behavior.